### PR TITLE
"Multi-Toggle with Active Parent Links - Pure CSS"

### DIFF
--- a/patterns.html
+++ b/patterns.html
@@ -111,6 +111,7 @@
 						<li><a href="http://codepen.io/JasonAGross/full/kEhHm">Multi-Toggle v2</a></li>
 						<li><a href="http://webdesigntutsplus.s3.amazonaws.com/tuts/378_tessa/tessa-lt-dropdowns-21c7868/index.html">Multi-Toggle v3</a></li>
 						<li><a href="http://codepen.io/micahgodbolt/full/czwer">Multi-Toggle with Active Parent Links</a></li>
+						<li><a href="http://codepen.io/micahgodbolt/full/mnLiF">Multi-Toggle with Active Parent Links - Pure CSS</a></li>
 						<li><a href="#" class="inactive">The Ol' Right-to-Left</a></li>
 						<li><a href="#" class="inactive">The Skip the Subnav</a></li>
 						<li><a href="#" class="inactive">The Carousel+</a></li>


### PR DESCRIPTION
Added "Multi-Toggle with Active Parent Links" variation, created with Pure CSS.

Example found at http://codepen.io/micahgodbolt/full/mnLiF

If you'd prefer removing the old JS version, I'd be fine with that.
