### PR TITLE
Fontier Chrome link change

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -427,7 +427,7 @@
 						<li><a href="https://github.com/izilla/Izilla-Media-Query-Debugger">Izilla Media Query Debugger</a></li>
 						<li><a href="http://quirktools.com/screenfly/">Screenfly</a></li>
 						<li><a href="http://www.jordanm.co.uk/lab/responsiveroulette">Responsive Roulette</a></li>
-						<li><a href="https://github.com/heartcode/fontier-chrome">Fontier for Chrome</a></li>
+						<li><a href="http://chrome.google.com/webstore/detail/fontier/dkbamaalakfhckcidgiigdinhcncaeae">Fontier for Chrome</a></li>
 					</ul>
 				</section>
 				<section id="device-testing">


### PR DESCRIPTION
The link now points to the Chrome Extension page on the Chrome Web Store.
