### PR TITLE
Word correction - "lines" instead of "lives"

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -495,7 +495,7 @@
                     <li><a href="http://drupal.org/project/zen">Zen: Sass+Compass base theme using Zen Grids</a></li>
                     <li><a href="http://drupal.org/project/omega">Omega Drupal 7 Base Theme</a></li>
                     <li><a href="http://mydrupalblog.lhmdesign.com/my-drupal-blog-case-study-upgrade-redesign-html5-responsive">My Drupal Blog - Case Study (Upgrade, Redesign, HTML5, Responsive)</a></li>
-                    <li><a href="http://www.zivtech.com/blog/responsive-drupal-theme-50-lines-code-or-less">A Responsive Drupal Theme in 50 Lives of Code or Less</a></li>
+                    <li><a href="http://www.zivtech.com/blog/responsive-drupal-theme-50-lines-code-or-less">A Responsive Drupal Theme in 50 Lines of Code or Less</a></li>
 				</ul>
 			</section>
 			<section id="ee">


### PR DESCRIPTION
Correcting the "50 Lives of Code or Less" link to "50 Lines of Code or Less"
