### PR TITLE
Incorrect Link for "Better Background Images for RWD"

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -309,7 +309,7 @@
 				<section id="background-images">
 					<h3><a href="#background-images">Background Images</a></h3>
 					<ul>
-						<li><a href="https://github.com/bradfrost/this-is-responsive/wiki/Responsive-Web-Design-Resources">Better background images for responsive web design</a></li>
+						<li><a href="http://elliotjaystocks.com/blog/better-background-images-for-responsive-web-design/">Better background images for responsive web design</a></li>
 					</ul>
 				</section>
 				<section id="hires-images">


### PR DESCRIPTION
I noticed that the link for "Better Background Images for Responsive Web Design" linked back to the main page for the repository, rather than to an article/post.

If we're thinking about the same post, Brad, then hopefully I've linked to the proper article, which was written by Elliot Jay Stocks here: http://elliotjaystocks.com/blog/better-background-images-for-responsive-web-design/
