### PR TITLE
Broken Resources Link in Components > Carousel

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -444,7 +444,7 @@
 					<h3><a href="#carousel">Carousel</a></h3>
 					<ul>
 						<li><a href="http://bradfrostweb.com/blog/post/the-overflow-pattern/">The Overflow Pattern</a></li>
-						<li><a href="http://www.uxde.net/2012/09/08/responsive-jquery-image-slider-plugins/">Best of:Responsive jQuery Image Slider Plugins</a></li>
+						<li><a href="http://www.uxde.net/blog/2012/09/08/responsive-jquery-image-slider-plugins/">Best of:Responsive jQuery Image Slider Plugins</a></li>
 						<li><a href="http://dimsemenov.com/plugins/royal-slider/">Royal Slider</a></li>
 						<li><a href="http://responsive-slides.viljamis.com/">Responsive Slides</a></li>
 					</ul>


### PR DESCRIPTION
The link to the "Best of: Responsive jQuery Image Slider Plugins" blog post is broken, and is resulting in a 404.
