### PR TITLE
Replace 320 and Up for Rock Hammer

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -158,7 +158,7 @@
 					<h3><a href="#frameworks">Frameworks/Boilerplates/Prototyping</a></h3>
 					<ul>
 						<li class="featured"><a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap</a></li>
-						<li class="featured"><a href="http://stuffandnonsense.co.uk/projects/320andup/">320 And Up</a></li>
+						<li class="featured"><a href="http://stuffandnonsense.co.uk/projects/rock-hammer/">Rock Hammer</a></li>
 						<li class="featured"><a href="http://foundation.zurb.com/">Foundation ZURB</a></li>
 						<li class="featured"><a href="http://lessframework.com/">LESS</a></li>
 						<li class="featured"><a href="http://jetstrap.com/">Jetstrap</a></li>


### PR DESCRIPTION
The framework 320 and Up was replaced by Rock Hammer and is no longer being developed. Maybe it´s better show only the active framework. 

More info http://stuffandnonsense.co.uk/projects/320andup/
