### PR TITLE
Fixing Broken Link

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -177,7 +177,7 @@
 					<h3><a href="#calculators">Calculators</a></h3>
 					<ul>
 					<li><a href="http://www.rwdcalc.com/">RWD Calc</a></li>
-					<li><a href="http://csswizardry.com/fluid-grids/">Fluid Grids</a></li>
+					<li><a href="http://csswizardry.com/2011/06/fluid-grid-calculator/">Fluid Grids</a></li>
 					<li><a href="http://ratiostrong.com/">RatioStrong</a></li>
 					<li><a href="http://pixelperc.com/">PixelPerc</a></li>
 					<li><a href="http://pxtoem.com/">PixeltoEm</a></li>


### PR DESCRIPTION
Under "calculators" the link to "fluid grids" was broken.
