### PR TITLE
Add an example for responsive, horizontal overflow navigation

### DIFF
--- a/patterns.html
+++ b/patterns.html
@@ -98,7 +98,7 @@
 						<li><a href="http://jsfiddle.net/csswizardry/ev598/">Overlay</a></li>
 						<li><a href="http://tympanus.net/Development/FullscreenOverlayStyles/">Fullscreen Overlay</a></li>
 						<li><a href="http://rutgerkooijman.nl/navigation/html/">Tabbed Nav</a></li>
-						<li><a href="#" class="inactive">Horizontal Overflow</a></li>
+						<li><a href="http://codepen.io/jordanmoore/pen/pnlAi">Horizontal Overflow</a></li>
 						<li><a href="http://jasonweaver.name/lab/flexiblenavigation/">Flexnav</a></li>
 					</ul>
 				</section>


### PR DESCRIPTION
Hey Brad,

I noticed that the link for a "Horizontal Overflow" navigation pattern was inactive, so, I activated it! I found a pretty neat example on Codepen that does not require any JS, check it out: http://codepen.io/jordanmoore/pen/pnlAi

If that is what you meant by "Horizontal Overflow", feel free to merge this in.

Thanks! :+1: 
Chris
