### PR TITLE
Fix typo in Resources

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -47,7 +47,7 @@
 						<li class="featured"><a href="http://responsive.rga.com/tagged/strategy">This Is Responsive Tagged 'Strategy'</a></li>
 						<li class="featured"><a href="http://www.lukew.com/ff/entry.asp?1509">Which One: Responsive Design, Device Experiences, or RESS?</a></li>
 						<li class="featured"><a href="http://mobiforge.com/starting/story/mobile-web-content-adaptation-techniques">Mobile web content adaptation techniques</a></li>
-						<li class="featured"><a href="http://stephanierieger.com/responsiveness-is-a-characteristic/">Responsiveness Is a Charactersic</a></li>
+						<li class="featured"><a href="http://stephanierieger.com/responsiveness-is-a-characteristic/">Responsiveness Is a Characteristic</a></li>
 						<li><a href="http://developers.facebook.com/html5/blog/post/6/">Device Experiences & Responsive Design</a></li>
 						<li><a href="http://dev.opera.com/articles/view/responsive-web-design-a-project-management-perspective/">Responsive web design: a project-management perspective</a></li>
 						<li><a href="http://uxmag.com/articles/a-primer-on-responsive-design">A Primer on Responsive Design</a></li>


### PR DESCRIPTION
I checked the linked article to be sure, and “Charactersic” should be “Characteristic”.
