### PR TITLE
Update WURFL Image Tailor to ImageEngine

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -552,7 +552,7 @@
 						<li><a href="https://github.com/johnkoht/responsive-images">Responsive Images for Ruby on Rails</a></li>
 						<li><a href="http://resrc.it/">ReSRC.it</a></li>
 						<li><a href="http://www.sencha.com/learn/how-to-use-src-sencha-io">Sencha.io Src</a></li>
-						<li><a href="http://wurfl.io/#wit">WURFL Image Tailor</a></li>
+						<li><a href="https://imageengine.io">ImageEngine</a></li>
 					</ul>
 				</section>
 				<section id="background-images">


### PR DESCRIPTION
WURFL Image Tailor is now called ImageEngine.